### PR TITLE
WSレスポンスのbodyフィールドにオブジェクト値以外が入っていても例外を吐かなくなった

### DIFF
--- a/Source/Disboard.Misskey/Models/Streaming/UnknownMessage.cs
+++ b/Source/Disboard.Misskey/Models/Streaming/UnknownMessage.cs
@@ -6,6 +6,6 @@ namespace Disboard.Misskey.Models.Streaming
 {
     public class UnknownMessage : IStreamMessage
     {
-        public JObject Body { get; set; }
+        public JToken Body { get; set; }
     }
 }

--- a/Source/Disboard.Misskey/Models/Streaming/WsResponseObject.cs
+++ b/Source/Disboard.Misskey/Models/Streaming/WsResponseObject.cs
@@ -14,7 +14,7 @@ namespace Disboard.Misskey.Models.Streaming
         public string Type { get; set; }
 
         [JsonProperty("body")]
-        public JObject RawBody { get; set; }
+        public JToken RawBody { get; set; }
 
         [JsonIgnore]
         public IStreamMessage Decoded { get; set; }


### PR DESCRIPTION
例の修正です