### PR TITLE
Wait() で起こりかねないデッドロックを回避

### DIFF
--- a/Source/Disboard.Misskey/Clients/Streaming/StreamingConnection.cs
+++ b/Source/Disboard.Misskey/Clients/Streaming/StreamingConnection.cs
@@ -7,6 +7,7 @@ using System.Net.WebSockets;
 using System.Threading.Tasks;
 
 using Disboard.Clients;
+using Disboard.Extensions;
 using Disboard.Misskey.Models;
 using Disboard.Misskey.Models.Streaming;
 using Disboard.Models;
@@ -33,7 +34,7 @@ namespace Disboard.Misskey.Clients.Streaming
 
         public async Task SendAsync(WsRequest request)
         {
-            await SendAsync(JsonConvert.SerializeObject(request));
+            await SendAsync(JsonConvert.SerializeObject(request)).Stay();
         }
 
         // Hmm...
@@ -42,7 +43,7 @@ namespace Disboard.Misskey.Clients.Streaming
             await Task.Run(() =>
             {
                 while (WebSocketClient == null || WebSocketClient.State != WebSocketState.Open) { }
-            });
+            }).Stay();
         }
 
         protected override bool IsMatchRequestAndResponse(object request, IStreamMessage response)

--- a/Source/Disboard/Clients/WebSocketStreamingConnection.cs
+++ b/Source/Disboard/Clients/WebSocketStreamingConnection.cs
@@ -99,7 +99,7 @@ namespace Disboard.Clients
                 throw new InvalidOperationException();
 
             var bytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(message));
-            await WebSocketClient.SendAsync(bytes, WebSocketMessageType.Text, true, new CancellationToken());
+            await WebSocketClient.SendAsync(bytes, WebSocketMessageType.Text, true, new CancellationToken()).Stay();
         }
 
         protected async Task<TU> SendAsync<TU>(string message) where TU : IStreamMessage


### PR DESCRIPTION
.NET Coreでは起きなかったのに、Xamarin 上で発生していたデッドロックをとりあえずねじ伏せてみました

現行Mobisskeyでしっかり動いています