### PR TITLE
fix(core): keep pagenator links' query strings

### DIFF
--- a/Source/Disboard/Models/Pagenator.cs
+++ b/Source/Disboard/Models/Pagenator.cs
@@ -96,7 +96,7 @@ namespace Disboard.Models
         // https://example.com/api/v1/... を /api/v1/... にするあれ
         private static string AsEndpoint(string str)
         {
-            return new Uri(str).AbsolutePath;
+            return new Uri(str).PathAndQuery;
         }
     }
 }


### PR DESCRIPTION
AsEndpointでクエリ文字列が取り除かれていたためPagenator<T>.XxxAsyncの結果がパラメータ無しで呼ばれたものになっていました。この修正でクエリ文字列が保存され正しくページネーションが行われることを確認しました。