### PR TITLE
fix(mastodon): fix type of Attachment.Id (int -> long)

### DIFF
--- a/Source/Disboard.Mastodon/Models/Attachment.cs
+++ b/Source/Disboard.Mastodon/Models/Attachment.cs
@@ -10,7 +10,7 @@ namespace Disboard.Mastodon.Models
     public class Attachment : ApiResponse
     {
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonProperty("type")]
         [JsonConverter(typeof(StringEnumConverter))]


### PR DESCRIPTION
Closes #27.

とりあえず `Attachment` だけ直しています。